### PR TITLE
RSDEV-444: Upgrade rspace-test-util to 3.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 2.0.0 2026-04-29
+- Spring 6 / Hibernate 6 / Jakarta namespace migration
+- Switch to rspace-parent 3.0.0
+
 ## 2.0.4
 - switch to parent-pom 2.1.0 (upgrades various apache-commons dependencies)
 - move away from apache commons-lang dependency (use commons-lang3 instead)

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rspace-test-util</artifactId>
-	<version>2.0.4</version>
+	<version>3.0.0</version>
 	<name>RSpace Test utilities</name>
 	<description>Utility classes used for testing across RSpace dependencies</description>
 
 	<parent>
 		<artifactId>rspace-parent</artifactId>
 		<groupId>com.github.rspace-os</groupId>
-		<version>2.1.0</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<repositories>
@@ -30,12 +30,12 @@
 	</build>
 
 	<dependencies>
-		<!-- requires implementation on classpathe.g. hibernate validator 1.1.0 
+		<!-- requires implementation on classpath. e.g. hibernate validator 1.1.0
 			is used by HibernateValidator 5.3 -->
 		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-			<version>${javax.validation.version}</version>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>${jakarta.validation.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rspace-test-util</artifactId>
-	<version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+	<version>3.0.0</version>
 	<name>RSpace Test utilities</name>
 	<description>Utility classes used for testing across RSpace dependencies</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rspace-test-util</artifactId>
-	<version>3.0.0</version>
+	<version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
 	<name>RSpace Test utilities</name>
 	<description>Utility classes used for testing across RSpace dependencies</description>
 
 	<parent>
 		<artifactId>rspace-parent</artifactId>
 		<groupId>com.github.rspace-os</groupId>
-		<version>3.0.0</version>
+		<version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
 	</parent>
 
 	<repositories>

--- a/src/main/java/com/researchspace/core/testutil/JakartaValidatorTest.java
+++ b/src/main/java/com/researchspace/core/testutil/JakartaValidatorTest.java
@@ -1,29 +1,28 @@
-package com.researchspace.core.testutilJU5;
+package com.researchspace.core.testutil;
 
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 
-import org.junit.jupiter.api.BeforeAll;
-
-import lombok.extern.slf4j.Slf4j;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 /**
- * Utility methods for testing Javax Validator annotations on a class.
- * PRovides a {@link Validator} instance to subclasses.
+ * Utility methods for testing Jakarta validation annotations on a class.
+ * Provides a {@link Validator} instance to subclasses.
  *
  */
-@Slf4j
-public abstract class JavaxValidatorTestJU5 {
+public abstract class JakartaValidatorTest {
 	
 	protected static Validator validator;
+	Logger log = LoggerFactory.getLogger(JakartaValidatorTest.class);
 	
-	@BeforeAll
+	@BeforeClass
 	public static void beforeClass() {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();	

--- a/src/main/java/com/researchspace/core/testutilJU5/JakartaValidatorTestJU5.java
+++ b/src/main/java/com/researchspace/core/testutilJU5/JakartaValidatorTestJU5.java
@@ -1,28 +1,29 @@
-package com.researchspace.core.testutil;
+package com.researchspace.core.testutilJU5;
 
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 
-import org.junit.BeforeClass;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.BeforeAll;
+
+import lombok.extern.slf4j.Slf4j;
 /**
- * Utility methods for testing Javax Validator annotations on a class.
- * PRovides a {@link Validator} instance to subclasses.
+ * Utility methods for testing Jakarta validation annotations on a class.
+ * Provides a {@link Validator} instance to subclasses.
  *
  */
-public abstract class JavaxValidatorTest {
+@Slf4j
+public abstract class JakartaValidatorTestJU5 {
 	
 	protected static Validator validator;
-	Logger log = LoggerFactory.getLogger(JavaxValidatorTest.class);
 	
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();	


### PR DESCRIPTION
Upgrade rspace-test-util to 3.0.0 for Spring 6 / Jakarta namespace migration (RSDEV-444).

Migrates validation imports from `javax.*` to `jakarta.*`. Renames `JavaxValidatorTest`/`JavaxValidatorTestJU5` to `JakartaValidator*`; all downstream consumers (rspace-core-model, rspace-web) have been updated.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>